### PR TITLE
change require call to lowercase

### DIFF
--- a/Ractive-transitions-scale.js
+++ b/Ractive-transitions-scale.js
@@ -52,7 +52,7 @@
 
 	// Common JS (i.e. browserify) environment
 	if ( typeof module !== 'undefined' && module.exports && typeof require === 'function' ) {
-		factory( require( 'Ractive' ) );
+		factory( require( 'ractive' ) );
 	}
 
 	// AMD?

--- a/Ractive-transitions-scale.js
+++ b/Ractive-transitions-scale.js
@@ -57,7 +57,7 @@
 
 	// AMD?
 	else if ( typeof define === 'function' && define.amd ) {
-		define([ 'Ractive' ], factory );
+		define([ 'ractive' ], factory );
 	}
 
 	// browser global


### PR DESCRIPTION
Change require call to lowercase to be consistent with other Ractive transition plugins, as well as RVC (Issue #3)